### PR TITLE
Adds script to run all parts of the backend in a development environment

### DIFF
--- a/start_development_environment.sh
+++ b/start_development_environment.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2012 NAMD-EMAP-FGV
+#
+# This file is part of PyPLN. You can get more information at: http://pypln.org/.
+#
+# PyPLN is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PyPLN is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyPLN. If not, see <http://www.gnu.org/licenses/>.
+
+SCRIPT_PATH=$(dirname $(readlink -f $0))
+echo "$SCRIPT_PATH"
+
+# Adding the current directory to PYTHONPATH, the broker will be able to import
+# pypln.backend even if the package is not installed
+export PYTHONPATH="$SCRIPT_PATH:$PYTHONPATH"
+
+echo "+-------------------------------------------------------+"
+echo "|     This script is intended for development only.     |"
+echo "| Please do not use it to run a production environment. |"
+echo "+-------------------------------------------------------+"
+
+echo "Starting router..."
+"$SCRIPT_PATH/pypln/backend/router.py" &
+ROUTER_PID=$!
+echo "Router has PID $ROUTER_PID"
+
+echo "Starting pipeliner..."
+"$SCRIPT_PATH/pypln/backend/pipeliner.py" &
+PIPELINER_PID=$!
+echo "Pipeliner has PID $PIPELINER_PID"
+
+echo "Starting broker..."
+"$SCRIPT_PATH/pypln/backend/broker.py" &
+BROKER_PID=$!
+echo "Broker has PID $BROKER_PID"
+
+trap "kill 0; exit" SIGINT SIGTERM SIGKILL
+
+while :
+do
+    sleep 1
+done


### PR DESCRIPTION
I have been bothered for a while by the fact that every time I start working on pypln.web I need to open three new terminals and start three different programs, so I wrote this little script to be used during development that runs the router, the pipeliner and the broker, to make my own life a little easier :) 
