### PR TITLE
Fixes ElasticIndexer for binary files

### DIFF
--- a/pypln/backend/workers/elastic_indexer.py
+++ b/pypln/backend/workers/elastic_indexer.py
@@ -32,6 +32,10 @@ class ElasticIndexer(PyPLNTask):
         doc_type = document.pop('doc_type')
         file_id = document["file_id"]
         ES.indices.create(index_name, ignore=400)
+        # We need to remove the raw contents of the file.
+        # See `test_regression_indexing_should_not_include_contents` in
+        # tests/test_elastic_indexer.py for details.
+        document.pop('contents')
         result = ES.index(index=index_name, doc_type=doc_type,
                 body=document, id=file_id)
         return result

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -3,3 +3,4 @@
 nose
 epydoc
 sphinx
+mock


### PR DESCRIPTION
We should not index the original file contents for two reasons: 1) they are not
relevant to the search. The `text` attribute should include the relevant
content and 2) they may be in a binary format that will not be serializable.

Fixes #176 