### PR TITLE
Skip tests if `palavras` is not installed

### DIFF
--- a/tests/test_worker_palavras_noun_phrase.py
+++ b/tests/test_worker_palavras_noun_phrase.py
@@ -17,14 +17,17 @@
 # You should have received a copy of the GNU General Public License
 # along with PyPLN.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest import skipIf
 from textwrap import dedent
 
 from pypln.backend.workers import NounPhrase
+from pypln.backend.workers.palavras_raw import palavras_installed
 from utils import TaskTest
 
 
 class TestNounPhraseWorker(TaskTest):
 
+    @skipIf(not palavras_installed(), 'palavras software is not installed')
     def test_noun_phrase_worker_should_return_a_list_with_phrases(self):
         palavras_output = dedent('''
         Eu\t[eu] <*> PERS M/F 1S NOM @SUBJ>  #1->2

--- a/tests/test_worker_palavras_raw.py
+++ b/tests/test_worker_palavras_raw.py
@@ -31,13 +31,12 @@ class TestPalavrasRawWorker(TaskTest):
 
     @skipIf(not palavras_raw.palavras_installed(), 'palavras software is not installed')
     def test_should_run_only_if_language_is_portuguese(self):
-        if palavras_raw.palavras_installed():
-            doc_id = self.collection.insert({'text': 'There was a rock on the way.',
-                'language': 'en'}, w=1)
+        doc_id = self.collection.insert({'text': 'There was a rock on the way.',
+            'language': 'en'}, w=1)
 
-            palavras_raw.PalavrasRaw().delay(doc_id)
-            refreshed_document = self.collection.find_one({'_id': doc_id})
-            self.assertEqual(refreshed_document['palavras_raw_ran'], False)
+        palavras_raw.PalavrasRaw().delay(doc_id)
+        refreshed_document = self.collection.find_one({'_id': doc_id})
+        self.assertEqual(refreshed_document['palavras_raw_ran'], False)
 
     @skipIf(not palavras_raw.palavras_installed(), 'palavras software is not installed')
     def test_palavras_not_installed(self):

--- a/tests/test_worker_palavras_raw.py
+++ b/tests/test_worker_palavras_raw.py
@@ -18,6 +18,7 @@
 # along with PyPLN.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from unittest import skipIf
 from textwrap import dedent
 
 from pypln.backend.workers import palavras_raw
@@ -28,6 +29,7 @@ ORIGINAL_PATH = palavras_raw.BASE_PARSER
 
 class TestPalavrasRawWorker(TaskTest):
 
+    @skipIf(not palavras_raw.palavras_installed(), 'palavras software is not installed')
     def test_should_run_only_if_language_is_portuguese(self):
         if palavras_raw.palavras_installed():
             doc_id = self.collection.insert({'text': 'There was a rock on the way.',
@@ -37,6 +39,7 @@ class TestPalavrasRawWorker(TaskTest):
             refreshed_document = self.collection.find_one({'_id': doc_id})
             self.assertEqual(refreshed_document['palavras_raw_ran'], False)
 
+    @skipIf(not palavras_raw.palavras_installed(), 'palavras software is not installed')
     def test_palavras_not_installed(self):
         palavras_raw.BASE_PARSER = '/not-found'
         doc_id = self.collection.insert(
@@ -47,6 +50,7 @@ class TestPalavrasRawWorker(TaskTest):
         self.assertEqual(refreshed_document['palavras_raw_ran'], False)
 
 
+    @skipIf(not palavras_raw.palavras_installed(), 'palavras software is not installed')
     def test_palavras_should_return_raw_if_it_is_installed(self):
         palavras_raw.BASE_PARSER = ORIGINAL_PATH
         doc_id = self.collection.insert(

--- a/tests/test_worker_palavras_raw.py
+++ b/tests/test_worker_palavras_raw.py
@@ -38,7 +38,6 @@ class TestPalavrasRawWorker(TaskTest):
         refreshed_document = self.collection.find_one({'_id': doc_id})
         self.assertEqual(refreshed_document['palavras_raw_ran'], False)
 
-    @skipIf(not palavras_raw.palavras_installed(), 'palavras software is not installed')
     def test_palavras_not_installed(self):
         palavras_raw.BASE_PARSER = '/not-found'
         doc_id = self.collection.insert(

--- a/tests/test_worker_palavras_raw.py
+++ b/tests/test_worker_palavras_raw.py
@@ -29,7 +29,6 @@ ORIGINAL_PATH = palavras_raw.BASE_PARSER
 
 class TestPalavrasRawWorker(TaskTest):
 
-    @skipIf(not palavras_raw.palavras_installed(), 'palavras software is not installed')
     def test_should_run_only_if_language_is_portuguese(self):
         doc_id = self.collection.insert({'text': 'There was a rock on the way.',
             'language': 'en'}, w=1)

--- a/tests/test_worker_pos.py
+++ b/tests/test_worker_pos.py
@@ -17,7 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with PyPLN.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest import skipIf
+
 from textwrap import dedent
+from pypln.backend.workers.palavras_raw import palavras_installed
 from pypln.backend.workers import POS
 from utils import TaskTest
 
@@ -38,6 +41,7 @@ class TestPosWorker(TaskTest):
         self.assertEqual(refreshed_document['pos'], expected)
         self.assertEqual(refreshed_document['tagset'], 'en-nltk')
 
+    @skipIf(not palavras_installed(), 'palavras software is not installed')
     def test_pos_should_run_pt_palavras_if_text_is_in_portuguese(self):
         text = 'Isso é uma frase em português.'
         tokens = ['Isso', 'é', 'uma', 'frase', 'em', 'português', '.']


### PR DESCRIPTION
Other institutions and companies are using pyPLN, so we don't have control of `palavras` software license. With this PR tests will be skipped if `palavras` is not installed.
